### PR TITLE
GG-14: Add search by name

### DIFF
--- a/persistence/src/main/java/io/github/lawseff/gadgets/persistence/GadgetRepository.java
+++ b/persistence/src/main/java/io/github/lawseff/gadgets/persistence/GadgetRepository.java
@@ -1,10 +1,15 @@
 package io.github.lawseff.gadgets.persistence;
 
 import io.github.lawseff.gadgets.persistence.entity.Gadget;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
 public interface GadgetRepository extends JpaRepository<Gadget, UUID> {
+
+  Page<Gadget> findByNameContainingIgnoreCase(Pageable pageable, String namePart);
+
 }

--- a/persistence/src/test/java/io/github/lawseff/gadgets/persistence/GadgetRepositoryTest.java
+++ b/persistence/src/test/java/io/github/lawseff/gadgets/persistence/GadgetRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -29,7 +30,7 @@ class GadgetRepositoryTest {
   }
 
   @Test
-  void repositoryWorks() {
+  void findAllWorks() {
     saveGadget("Foo", 100, 150, 200);
     saveGadget("Bar", 250, 300, 350);
 
@@ -49,6 +50,33 @@ class GadgetRepositoryTest {
       softly.assertThat(bar.getDimensions().getLengthMillimeters()).isCloseTo(250, COMPARISON_TOLERANCE);
       softly.assertThat(bar.getDimensions().getWidthMillimeters()).isCloseTo(300, COMPARISON_TOLERANCE);
       softly.assertThat(bar.getDimensions().getHeightMillimeters()).isCloseTo(350, COMPARISON_TOLERANCE);
+    });
+  }
+
+  @Test
+  void findByNameWorks() {
+    saveGadget("Foo", 300, 450, 500);
+    saveGadget("Video Game Console", 100, 150, 200);
+    saveGadget("Bar", 250, 300, 350);
+    saveGadget("VIDEO GAME CONSOLE 2", 1000, 1100, 1200);
+
+    var result = repository.findByNameContainingIgnoreCase(PageRequest.of(0, 10), "conso");
+
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertSoftly(softly -> {
+      var gadgets = result.get().toList();
+      var console1 = gadgets.get(0);
+      softly.assertThat(console1.getId()).isNotNull();
+      softly.assertThat(console1.getName()).isEqualTo("Video Game Console");
+      softly.assertThat(console1.getDimensions().getLengthMillimeters()).isCloseTo(100, COMPARISON_TOLERANCE);
+      softly.assertThat(console1.getDimensions().getWidthMillimeters()).isCloseTo(150, COMPARISON_TOLERANCE);
+      softly.assertThat(console1.getDimensions().getHeightMillimeters()).isCloseTo(200, COMPARISON_TOLERANCE);
+      var console2 = gadgets.get(1);
+      softly.assertThat(console2.getId()).isNotNull();
+      softly.assertThat(console2.getName()).isEqualTo("VIDEO GAME CONSOLE 2");
+      softly.assertThat(console2.getDimensions().getLengthMillimeters()).isCloseTo(1000, COMPARISON_TOLERANCE);
+      softly.assertThat(console2.getDimensions().getWidthMillimeters()).isCloseTo(1100, COMPARISON_TOLERANCE);
+      softly.assertThat(console2.getDimensions().getHeightMillimeters()).isCloseTo(1200, COMPARISON_TOLERANCE);
     });
   }
 

--- a/service/src/main/java/io/github/lawseff/gadgets/service/GadgetService.java
+++ b/service/src/main/java/io/github/lawseff/gadgets/service/GadgetService.java
@@ -11,29 +11,46 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import java.util.Locale;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class GadgetService {
 
-  private static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.ASC, "name");
+  /**
+   * Regex for two or more whitespace characters
+   */
+  private static final String MULTIPLE_WHITESPACES = "\\s{2,}";
+
+  /**
+   * Single space character
+   */
+  private static final String SINGLE_SPACE = " ";
 
   private final GadgetRepository repository;
 
   private final GadgetMapper mapper;
 
   public SearchResponse<GadgetDto> findGadgets(SearchRequest request) {
-    var gadgetPage = repository.findAll(mapToPageable(request));
-    return mapToResponse(gadgetPage);
+    Pageable pageable = PageRequest.of(request.pageNumber(), request.pageSize());
+    var searchString = prepareSearchString(request);
+    var data = searchString.isPresent()
+        ? repository.findByNameContainingIgnoreCase(pageable, searchString.get())
+        : repository.findAll(pageable);
+    return mapToResponse(data, searchString);
   }
 
-  private Pageable mapToPageable(SearchRequest request) {
-    return PageRequest.of(request.pageNumber(), request.pageSize(), DEFAULT_SORT);
+  private Optional<String> prepareSearchString(SearchRequest request) {
+    return Optional.ofNullable(request.searchString())
+        // Converts to lowercase for a prettier string in the response DTO
+        .map(searchString -> searchString.toLowerCase(Locale.US)
+            .trim().replaceAll(MULTIPLE_WHITESPACES, SINGLE_SPACE)
+        );
   }
 
-  private SearchResponse<GadgetDto> mapToResponse(Page<Gadget> page) {
+  private SearchResponse<GadgetDto> mapToResponse(Page<Gadget> page, Optional<String> searchString) {
     return new SearchResponse<>(
         page.get().map(mapper::mapToDto).toList(),
         new PaginationDto(
@@ -41,7 +58,8 @@ public class GadgetService {
             page.getTotalPages(),
             page.getNumber(),
             page.getSize()
-        )
+        ),
+        searchString.orElse(null)
     );
   }
 

--- a/service/src/main/java/io/github/lawseff/gadgets/service/search/SearchRequest.java
+++ b/service/src/main/java/io/github/lawseff/gadgets/service/search/SearchRequest.java
@@ -4,6 +4,8 @@ public record SearchRequest(
 
     int pageNumber,
 
-    int pageSize
+    int pageSize,
+
+    String searchString
 
 ) {}

--- a/service/src/main/java/io/github/lawseff/gadgets/service/search/SearchResponse.java
+++ b/service/src/main/java/io/github/lawseff/gadgets/service/search/SearchResponse.java
@@ -1,11 +1,15 @@
 package io.github.lawseff.gadgets.service.search;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public record SearchResponse<T>(
 
     List<T> data,
 
-    PaginationDto pagination
+    PaginationDto pagination,
+
+    @JsonProperty("search")
+    String searchString
 
 ) {}

--- a/web/src/main/java/io/github/lawseff/gadgets/web/controller/GadgetController.java
+++ b/web/src/main/java/io/github/lawseff/gadgets/web/controller/GadgetController.java
@@ -11,7 +11,10 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 @RestController
@@ -24,16 +27,20 @@ public class GadgetController {
 
   @GetMapping("/gadgets")
   public ResponseEntity<SearchResponse<GadgetDto>> findGadgets(
-      @PageableDefault(size = 12) Pageable pageable
+      @PageableDefault(size = 12, sort = "name") Pageable pageable,
+      @RequestParam(name = "search", required = false) String searchString
   ) {
-    var search = new SearchRequest(pageable.getPageNumber(), pageable.getPageSize());
+    // For some reason, Spring doesn't decode the query param ('%20' and '+' aren't decoded to space)
+    var decodedSearchString = searchString != null ? URLDecoder.decode(searchString, StandardCharsets.UTF_8) : null;
+    var search = new SearchRequest(pageable.getPageNumber(), pageable.getPageSize(), decodedSearchString);
     var result = service.findGadgets(search);
     var body = new SearchResponse<>(
         result.data(),
         // The logic uses 0-based pagination, but for the client it starts from 1. The page number is decremented by 1
         // during mapping, because 'spring.data.web.pageable.one-indexed-parameters' is enabled. To include the correct
         // pagination to the response, incrementing it back by 1
-        incrementPageNumber(result.pagination())
+        incrementPageNumber(result.pagination()),
+        result.searchString()
     );
     return ResponseEntity.ok()
         .cacheControl(CACHE_CONTROL)

--- a/web/src/test/java/io/github/lawseff/gadgets/web/controller/GadgetControllerTest.java
+++ b/web/src/test/java/io/github/lawseff/gadgets/web/controller/GadgetControllerTest.java
@@ -5,8 +5,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class GadgetControllerTest extends ApiTest {
 
@@ -114,7 +117,8 @@ class GadgetControllerTest extends ApiTest {
                 "totalPages": 1,
                 "page": 1,
                 "size": 12
-              }
+              },
+              "search": null
             }
             """.formatted(
                 testData.getActionCamera().getId(),
@@ -180,7 +184,8 @@ class GadgetControllerTest extends ApiTest {
                 "totalPages": 3,
                 "page": 2,
                 "size": 3
-              }
+              },
+              "search": null
             }
             """.formatted(
                 testData.getDrone().getId(),
@@ -188,6 +193,44 @@ class GadgetControllerTest extends ApiTest {
                 testData.getFitnessTracker().getId()
             ),
             // Strict assert for array ordering
+            true
+        ));
+  }
+
+  @Test
+  void searchWorks() throws Exception {
+    mockMvc.perform(get("/gadgets?search=tooTH+++speak"))
+        .andExpect(status().isOk())
+        .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "max-age=3600"))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            """
+            {
+              "data": [
+                {
+                  "id": "%s",
+                  "name": "Bluetooth Speaker",
+                  "dimensions": {
+                    "unit": "MM",
+                    "length": 150,
+                    "width": 80,
+                    "height": 25
+                  },
+                  "imageUrl": null
+                }
+              ],
+              "pagination": {
+                "totalElements": 1,
+                "totalPages": 1,
+                "page": 1,
+                "size": 12
+              },
+              "search": "tooth speak"
+            }
+            """.formatted(
+                testData.getBluetoothSpeaker().getId()
+            ),
+            // Strict assert for exact fields
             true
         ));
   }


### PR DESCRIPTION
A user may want to search for specific gadgets. The commit adds an ability
to search them by the name. The new query parameter is introduced:

```http
GET /gadgets?search=word+another
```

The search is case-insensitive and multiple spaces are treated as single.
Both the `%20` and `+` encodings are supported.
For some reason, Spring doesn't decode the query param automatically, so
it is done manually. Also the response API is extended with a new
field, containing the search string.