### PR TITLE
GG-27: Use Testcontainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,11 @@
 
 ## Local development
 
+### Database
+
 For local development a database is needed.
 To initialize the database, please see [persistence/README.md](persistence/README.md). 
+
+### Profile
+
+Run the application with the `local` profile to apply the local configuration.

--- a/persistence-test/pom.xml
+++ b/persistence-test/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.lawseff</groupId>
+        <artifactId>gadget-grid-api</artifactId>
+        <version>0.1.0-SNAPHSOT</version>
+    </parent>
+    <artifactId>persistence-test</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>persistence-test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
+        <!-- Testcontainers: Adds an automatic container lifecycle management (@Testcontainers and
+        @Container) -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <!-- Testcontainers: adds an automatic data source configuration (@ServiceConnection) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+        </dependency>
+        <!-- Testcontainers: adds the Postgres Testcontainers implementation -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/persistence-test/src/main/java/io/github/lawseff/gadgets/persistence/test/DatabaseTest.java
+++ b/persistence-test/src/main/java/io/github/lawseff/gadgets/persistence/test/DatabaseTest.java
@@ -1,0 +1,21 @@
+package io.github.lawseff.gadgets.persistence.test;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+// The Hikari Pool needs to be recreated, because the container is recreated. Otherwise, next tests
+// try to access the already stopped container: https://stackoverflow.com/a/65952397
+@DirtiesContext
+public class DatabaseTest {
+
+  @Container
+  @ServiceConnection
+  private static final PostgreSQLContainer<?> POSTGRES_TEST_CONTAINER = new PostgreSQLContainer<>(
+      System.getProperty("test.postgresql.image")
+  );
+
+}

--- a/persistence-test/src/test/java/io/github/lawseff/gadgets/persistence/test/ContainerDatabaseTest.java
+++ b/persistence-test/src/test/java/io/github/lawseff/gadgets/persistence/test/ContainerDatabaseTest.java
@@ -1,0 +1,15 @@
+package io.github.lawseff.gadgets.persistence.test;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@SpringBootApplication
+class ContainerDatabaseTest extends DatabaseTest {
+
+  @Test
+  void contextLoads() {
+  }
+
+}

--- a/persistence/create_databases.sql
+++ b/persistence/create_databases.sql
@@ -1,6 +1,3 @@
 -- Local environment
 CREATE USER gadgets LOGIN PASSWORD 'gadgets';
 CREATE DATABASE gadgets OWNER gadgets;
--- Test environment
-CREATE USER gadgets_test LOGIN PASSWORD 'gadgets_test';
-CREATE DATABASE gadgets_test OWNER gadgets_test;

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>io.github.lawseff</groupId>
+            <artifactId>persistence-test</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/persistence/src/test/java/io/github/lawseff/gadgets/persistence/gadget/GadgetRepositoryTest.java
+++ b/persistence/src/test/java/io/github/lawseff/gadgets/persistence/gadget/GadgetRepositoryTest.java
@@ -1,9 +1,9 @@
 package io.github.lawseff.gadgets.persistence.gadget;
 
 import io.github.lawseff.gadgets.persistence.EntityNotFoundException;
+import io.github.lawseff.gadgets.persistence.test.DatabaseTest;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.data.Offset;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @DataJpaTest
-class GadgetRepositoryTest {
+class GadgetRepositoryTest extends DatabaseTest {
 
   /**
    * Indicates how close double values should be to the expected result (absolute value).
@@ -25,11 +25,6 @@ class GadgetRepositoryTest {
 
   @Autowired
   private GadgetRepository repository;
-
-  @BeforeEach
-  void setUp() {
-    repository.deleteAll();
-  }
 
   @Test
   void findAllWorks() {

--- a/persistence/src/test/resources/application.yaml
+++ b/persistence/src/test/resources/application.yaml
@@ -1,13 +1,9 @@
 spring:
   test:
     database:
-      # By default, JPA tests (@DataJpaTest) override the datasource with an embedded one. It's not in the classpath,
-      # so the initialization fails. Therefore, disabling it to use our own datasource
+      # By default, JPA tests (@DataJpaTest) override the datasource with an embedded one.
+      # Disabling it, because it's not provided at runtime and Testcontainers are used instead
       replace: none
-  datasource:
-    url: jdbc:postgresql://localhost:5432/gadgets_test
-    username: gadgets_test
-    password: gadgets_test
   liquibase:
     change-log: classpath:db/changelog/changelog-root.xml
     contexts: test

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,10 @@
 
     <properties>
         <java.version>21</java.version>
+        <project.build.surefire.version>3.2.5</project.build.surefire.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <test.postgresql.image>postgres:16.2</test.postgresql.image>
     </properties>
 
     <packaging>pom</packaging>
@@ -25,7 +27,41 @@
         <module>persistence</module>
         <module>service</module>
         <module>web</module>
+        <module>persistence-test</module>
     </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!--  Sets system properties for the application -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${project.build.surefire.version}</version>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <test.postgresql.image>${test.postgresql.image}</test.postgresql.image>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Fixes the vulnerabilities of commons-compress, the transitive dependency of
+            org.testcontainers:junit-jupiter:
+            - CVE-2024-26308
+            - CVE-2024-25710
+            -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -27,8 +27,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>io.github.lawseff</groupId>
+            <artifactId>persistence-test</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/web/src/test/java/io/github/lawseff/gadgets/web/ApiTest.java
+++ b/web/src/test/java/io/github/lawseff/gadgets/web/ApiTest.java
@@ -3,20 +3,21 @@ package io.github.lawseff.gadgets.web;
 import io.github.lawseff.gadgets.persistence.gadget.GadgetRepository;
 import io.github.lawseff.gadgets.persistence.gadget.Dimensions;
 import io.github.lawseff.gadgets.persistence.gadget.Gadget;
+import io.github.lawseff.gadgets.persistence.test.DatabaseTest;
 import lombok.Getter;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-public abstract class ApiTest {
+// Note: @TestInstance(TestInstance.Lifecycle.PER_CLASS) doesn't work with the test containers
+// auto-start: https://github.com/testcontainers/testcontainers-java/issues/2290
+public abstract class ApiTest extends DatabaseTest {
 
   @Autowired
   protected MockMvc mockMvc;
@@ -26,7 +27,7 @@ public abstract class ApiTest {
   @Autowired
   private GadgetRepository repository;
 
-  @BeforeAll
+  @BeforeEach
   void setUp() {
     repository.deleteAll();
     testData.saveAll();

--- a/web/src/test/resources/application-test.yaml
+++ b/web/src/test/resources/application-test.yaml
@@ -1,7 +1,3 @@
 spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/gadgets_test
-    username: gadgets_test
-    password: gadgets_test
   liquibase:
     contexts: test


### PR DESCRIPTION
A test database is used in the API / persistence tests. Previously, the local container with Postgres had a database for `test`. The commit introduces the Testcontainers DB instead. It's done, so that the tests don't require the container running constantly on the specific port. Also it will be easier to add new services in the tests (e.g. MinIO)