### PR TITLE
Remove DB initialization script

### DIFF
--- a/persistence/Dockerfile
+++ b/persistence/Dockerfile
@@ -1,13 +1,12 @@
+# Only for local development!
+
 # The PostgreSQL image
 FROM postgres:16.2
 
-# The defaults for easy `psql`. Only for local development!
-ENV POSTGRES_DB root
-ENV POSTGRES_USER root
-ENV POSTGRES_PASSWORD root
+# The database & user
+ENV POSTGRES_DB gadgets
+ENV POSTGRES_USER gadgets
+ENV POSTGRES_PASSWORD gadgets
 
 # Exposes the container's port for access from the host
 EXPOSE 5432
-
-# Creates the databases
-COPY create_databases.sql /docker-entrypoint-initdb.d/

--- a/persistence/create_databases.sql
+++ b/persistence/create_databases.sql
@@ -1,3 +1,0 @@
--- Local environment
-CREATE USER gadgets LOGIN PASSWORD 'gadgets';
-CREATE DATABASE gadgets OWNER gadgets;


### PR DESCRIPTION
Since the test DB is created by Testcontainers now, the old test DB had been removed from the initialization script previously. After that the script had only one DB (`local`).
Now it can be inlined to the Dockerfile instead of the script.